### PR TITLE
Fix typo causing vignette not to show up in listing and on CRAN

### DIFF
--- a/vignettes/ecoms_forecast_verification.pdf.asis
+++ b/vignettes/ecoms_forecast_verification.pdf.asis
@@ -1,2 +1,2 @@
 %\VignetteIndexEntry{Verification of seasonal forecasts from the ECOMS User Data Gateway: a worked example}
-%\VignetteEngine{R.rsp:asis}
+%\VignetteEngine{R.rsp::asis}


### PR DESCRIPTION
FYI, the reason for the static PDF vignette not showing up in `vignette(package="easyVerification")` and on [CRAN](https://cran.r-project.org/web/packages/easyVerification/) is because of this typo.